### PR TITLE
Use STS to get the AWS account ID

### DIFF
--- a/src/lein_lambda/identitymanagement.clj
+++ b/src/lein_lambda/identitymanagement.clj
@@ -1,14 +1,10 @@
 (ns lein-lambda.identitymanagement
   (:require [clojure.string :as string]
-            [amazonica.aws.identitymanagement :as amazon]))
+            [amazonica.aws.identitymanagement :as amazon]
+            [amazonica.aws.securitytoken :as sts]))
 
-; Sadly, this seems to be the only way to get the account ID :-(
-; https://stackoverflow.com/questions/10197784/how-can-i-deduce-the-aws-account-id-from-available-basicawscredentials
 (defn account-id []
-  (-> (amazon/get-user)
-    (get-in [:user :arn])
-    (string/split #":")
-    (nth 4)))
+  (get-in (sts/get-caller-identity {}) [:account]))
 
 (defn- get-role-arn [name]
   (get-in (amazon/get-role :role-name name) [:role :arn]))


### PR DESCRIPTION
This is more reliable than using the iam call, as it will work with
assumed roles and doesn't rely on a user having IAM access.