### PR TITLE
Update dependencies and formatting of project.clj

### DIFF
--- a/template/resources/leiningen/new/lambda_api/project.clj
+++ b/template/resources/leiningen/new/lambda_api/project.clj
@@ -2,22 +2,22 @@
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [compojure "1.6.0"]
-                 [ring/ring-defaults "0.3.1"]
-                 [ring/ring-json "0.4.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [compojure "1.6.1"]
+                 [ring/ring-defaults "0.3.2"]
+                 [ring/ring-json "0.5.0"]
                  [uswitch/lambada "0.1.2"]
                  [cheshire "5.7.1"]
                  [ring-apigw-lambda-proxy "0.3.0"]]
-  :plugins [[lein-ring "0.9.7"]
+  :plugins [[lein-ring "0.12.5"]
+            [lein-cljfmt "0.6.4"]
             [lein-lambda "0.2.0"]]
   :ring {:handler {{name}}.handler/app}
-  :profiles
-  {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
-                        [ring/ring-mock "0.3.1"]]}
-   :uberjar {:aot :all}}
+  :profiles {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
+                                  [ring/ring-mock "0.3.1"]]}
+             :uberjar {:aot :all}}
   :lambda {:function {:name "{{name}}"
                       :handler "{{name}}.lambda.LambdaFn"}
            :api-gateway {:name "{{name}}"}
            :stages {"production" {:warmup {:enable true}}
-                    "staging"    {}}})
+                    "staging" {}}})


### PR DESCRIPTION
I updated the dependecies  and plugins in project.clj so that also local development with `lein ring server-headless` works with newer versions. Especially the "lein-ring" plugins has to be updated.
The problem is described here: https://stackoverflow.com/a/55173713/669561

I tested the new dependencies locally and also with AWS lambda deployments.

I also changed the formatting and indentation slightly. The original indentation of the :uberjar confused me at the beginning and I deleted one whitespace character. Using parinfer this also changed the structure and the the deploys to lambda did not work anymore.

I hope with the new formatting it should also be clearer for beginners.

